### PR TITLE
Fix create_associated_token_account

### DIFF
--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -63,8 +63,12 @@ pub fn mint(
     let assoc = get_associated_token_address(&receiver, &mint.pubkey());
 
     // Create associated account instruction
-    let create_assoc_account_ix =
-        create_associated_token_account(&funder.pubkey(), &receiver, &mint.pubkey());
+    let create_assoc_account_ix = create_associated_token_account(
+        &funder.pubkey(),
+        &receiver,
+        &mint.pubkey(),
+        &TOKEN_PROGRAM_ID,
+    );
 
     // Mint to instruction
     let mint_to_ix = mint_to(


### PR DESCRIPTION
Add missing 4th parameter create_associated_token_account &Pubkey reference from dependency code:
https://github.com/solana-labs/solana-program-library/blob/290d8d880a3d03da320fe14fbc18287abbd0fb77/associated-token-account/program/src/instruction.rs#L70

Issue found at https://github.com/samuelvanderwaal/metaboss/issues/175