### PR TITLE
add decode_master; refactor

### DIFF
--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -2,7 +2,7 @@ use mpl_token_metadata::state::{
     Edition, EditionMarker, MasterEditionV2, Metadata, TokenMetadataAccount,
 };
 use solana_client::rpc_client::RpcClient;
-use solana_program::{borsh::try_from_slice_unchecked, program_pack::Pack};
+use solana_program::program_pack::Pack;
 use solana_sdk::pubkey::Pubkey;
 use spl_token::state::Mint;
 use std::str::FromStr;
@@ -11,24 +11,37 @@ pub mod errors;
 use crate::derive::*;
 use errors::DecodeError;
 
-pub fn decode_metadata_from_mint(
-    client: &RpcClient,
-    mint_address: &str,
-) -> Result<Metadata, DecodeError> {
-    let pubkey = match Pubkey::from_str(mint_address) {
-        Ok(pubkey) => pubkey,
-        Err(_) => return Err(DecodeError::PubkeyParseFailed(mint_address.to_string())),
-    };
-    let metadata_pda = derive_metadata_pda(&pubkey);
+pub trait ToPubkey {
+    fn to_pubkey(self) -> Result<Pubkey, DecodeError>;
+}
 
-    let account_data = match client.get_account_data(&metadata_pda) {
+impl ToPubkey for String {
+    fn to_pubkey(self) -> Result<Pubkey, DecodeError> {
+        Pubkey::from_str(&self).map_err(|_| DecodeError::PubkeyParseFailed(self))
+    }
+}
+
+impl ToPubkey for &str {
+    fn to_pubkey(self) -> Result<Pubkey, DecodeError> {
+        Pubkey::from_str(self).map_err(|_| DecodeError::PubkeyParseFailed(self.to_string()))
+    }
+}
+
+impl ToPubkey for Pubkey {
+    fn to_pubkey(self) -> Result<Pubkey, DecodeError> {
+        Ok(self)
+    }
+}
+
+pub fn decode_metadata(client: &RpcClient, pubkey: &Pubkey) -> Result<Metadata, DecodeError> {
+    let account_data = match client.get_account_data(pubkey) {
         Ok(data) => data,
         Err(err) => {
             return Err(DecodeError::ClientError(err.kind));
         }
     };
 
-    let metadata: Metadata = match try_from_slice_unchecked(&account_data) {
+    let metadata: Metadata = match Metadata::safe_deserialize(&account_data) {
         Ok(m) => m,
         Err(err) => return Err(DecodeError::DecodeMetadataFailed(err.to_string())),
     };
@@ -36,51 +49,31 @@ pub fn decode_metadata_from_mint(
     Ok(metadata)
 }
 
-pub fn decode_master_edition_from_mint(
-    client: &RpcClient,
-    mint_address: &str,
-) -> Result<MasterEditionV2, DecodeError> {
-    let pubkey = match Pubkey::from_str(mint_address) {
-        Ok(pubkey) => pubkey,
-        Err(_) => return Err(DecodeError::PubkeyParseFailed(mint_address.to_string())),
-    };
-
-    let edition_pda = derive_edition_pda(&pubkey);
-
-    let account_data = match client.get_account_data(&edition_pda) {
+pub fn decode_master(client: &RpcClient, pubkey: &Pubkey) -> Result<MasterEditionV2, DecodeError> {
+    let account_data = match client.get_account_data(pubkey) {
         Ok(data) => data,
         Err(err) => {
             return Err(DecodeError::ClientError(err.kind));
         }
     };
 
-    let master_edition: MasterEditionV2 = match try_from_slice_unchecked(&account_data) {
-        Ok(e) => e,
+    let master_edition: MasterEditionV2 = match MasterEditionV2::safe_deserialize(&account_data) {
+        Ok(m) => m,
         Err(err) => return Err(DecodeError::DecodeMetadataFailed(err.to_string())),
     };
 
     Ok(master_edition)
 }
 
-pub fn decode_edition_from_mint(
-    client: &RpcClient,
-    mint_address: &str,
-) -> Result<Edition, DecodeError> {
-    let pubkey = match Pubkey::from_str(mint_address) {
-        Ok(pubkey) => pubkey,
-        Err(_) => return Err(DecodeError::PubkeyParseFailed(mint_address.to_string())),
-    };
-
-    let edition_pda = derive_edition_pda(&pubkey);
-
-    let account_data = match client.get_account_data(&edition_pda) {
+pub fn decode_edition(client: &RpcClient, pubkey: &Pubkey) -> Result<Edition, DecodeError> {
+    let account_data = match client.get_account_data(pubkey) {
         Ok(data) => data,
         Err(err) => {
             return Err(DecodeError::ClientError(err.kind));
         }
     };
 
-    let edition: Edition = match try_from_slice_unchecked(&account_data) {
+    let edition: Edition = match Edition::safe_deserialize(&account_data) {
         Ok(e) => e,
         Err(err) => return Err(DecodeError::DecodeMetadataFailed(err.to_string())),
     };
@@ -88,11 +81,40 @@ pub fn decode_edition_from_mint(
     Ok(edition)
 }
 
-pub fn decode_mint(client: &RpcClient, mint_address: &str) -> Result<Mint, DecodeError> {
-    let pubkey = match Pubkey::from_str(mint_address) {
-        Ok(pubkey) => pubkey,
-        Err(_) => return Err(DecodeError::PubkeyParseFailed(mint_address.to_string())),
-    };
+pub fn decode_metadata_from_mint<P: ToPubkey>(
+    client: &RpcClient,
+    mint_address: P,
+) -> Result<Metadata, DecodeError> {
+    let pubkey = mint_address.to_pubkey()?;
+    let metadata_pda = derive_metadata_pda(&pubkey);
+
+    decode_metadata(client, &metadata_pda)
+}
+
+pub fn decode_master_edition_from_mint<P: ToPubkey>(
+    client: &RpcClient,
+    mint_address: P,
+) -> Result<MasterEditionV2, DecodeError> {
+    let pubkey = mint_address.to_pubkey()?;
+
+    let edition_pda = derive_edition_pda(&pubkey);
+
+    decode_master(client, &edition_pda)
+}
+
+pub fn decode_edition_from_mint<P: ToPubkey>(
+    client: &RpcClient,
+    mint_address: P,
+) -> Result<Edition, DecodeError> {
+    let pubkey = mint_address.to_pubkey()?;
+
+    let edition_pda = derive_edition_pda(&pubkey);
+
+    decode_edition(client, &edition_pda)
+}
+
+pub fn decode_mint<P: ToPubkey>(client: &RpcClient, mint_address: P) -> Result<Mint, DecodeError> {
+    let pubkey = mint_address.to_pubkey()?;
 
     let account = match client.get_account(&pubkey) {
         Ok(account) => account,
@@ -109,15 +131,12 @@ pub fn decode_mint(client: &RpcClient, mint_address: &str) -> Result<Mint, Decod
     Ok(mint)
 }
 
-pub fn decode_edition_marker_from_mint(
+pub fn decode_edition_marker_from_mint<P: ToPubkey>(
     client: &RpcClient,
-    mint_address: &str,
+    mint_address: P,
     edition_num: u64,
 ) -> Result<EditionMarker, DecodeError> {
-    let pubkey = match Pubkey::from_str(mint_address) {
-        Ok(pubkey) => pubkey,
-        Err(_) => return Err(DecodeError::PubkeyParseFailed(mint_address.to_string())),
-    };
+    let pubkey = mint_address.to_pubkey()?;
 
     let edition_marker_pda = derive_edition_marker_pda(&pubkey, edition_num);
 

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -1,7 +1,9 @@
 use anyhow::Result;
 use mpl_token_metadata::{
     id,
-    instruction::{create_master_edition, create_metadata_accounts, update_metadata_accounts},
+    instruction::{
+        create_master_edition_v3, create_metadata_accounts, update_metadata_accounts_v2,
+    },
 };
 use retry::{delay::Exponential, retry};
 use solana_client::rpc_client::RpcClient;
@@ -111,7 +113,7 @@ pub fn mint(
         !immutable,
     );
 
-    let create_master_edition_account_ix = create_master_edition(
+    let create_master_edition_account_ix = create_master_edition_v3(
         metaplex_program_id,
         master_edition_account,
         mint.pubkey(),
@@ -132,13 +134,14 @@ pub fn mint(
     ];
 
     if primary_sale_happened {
-        let ix = update_metadata_accounts(
+        let ix = update_metadata_accounts_v2(
             metaplex_program_id,
             metadata_account,
             funder.pubkey(),
             None,
             None,
             Some(true),
+            None,
         );
         instructions.push(ix);
     }

--- a/src/mint/mod.rs
+++ b/src/mint/mod.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use mpl_token_metadata::{
     id,
     instruction::{
-        create_master_edition_v3, create_metadata_accounts, update_metadata_accounts_v2,
+        create_master_edition_v3, create_metadata_accounts_v3, update_metadata_accounts_v2,
     },
 };
 use retry::{delay::Exponential, retry};
@@ -97,7 +97,7 @@ pub fn mint(
     let (master_edition_account, _pda) =
         Pubkey::find_program_address(master_edition_seeds, &metaplex_program_id);
 
-    let create_metadata_account_ix = create_metadata_accounts(
+    let create_metadata_account_ix = create_metadata_accounts_v3(
         metaplex_program_id,
         metadata_account,
         mint.pubkey(),
@@ -111,6 +111,9 @@ pub fn mint(
         data.seller_fee_basis_points,
         true,
         !immutable,
+        None,
+        None,
+        None,
     );
 
     let create_master_edition_account_ix = create_master_edition_v3(


### PR DESCRIPTION
Adds `ToPubkey` trait to allow decode functions to take `&str`, `String` and `Pubkey`. Refactors decode to add `decode_metadata` function, use the new trait, and have `_from_mint` functions use the direct decoders.