### PR TITLE
Add token auth rules program

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 [dependencies]
 anyhow = "1.0.52"
 mpl-token-metadata = { version = "1.9.0", features = ["no-entrypoint", "serde-feature"] }
+mpl-token-auth-rules = { version = "1.3.0", features = ["no-entrypoint"] }
 retry = "1.3.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.91"

--- a/src/transfer/mod.rs
+++ b/src/transfer/mod.rs
@@ -97,6 +97,7 @@ fn transfer_asset_v1<P: ToPubkey>(
             rule_set: Some(auth_rules),
         }) = md.programmable_config
         {
+            transfer_builder.authorization_rules_program(mpl_token_auth_rules::ID);
             transfer_builder.authorization_rules(auth_rules);
         }
     }


### PR DESCRIPTION
This PR adds the `mpl_token_auth_rules` program on the transfer builder, required for `pNFT` transfers.