### PR TITLE
fix: Metadata Account Decoding Errors

### DIFF
--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -43,7 +43,7 @@ pub fn decode_metadata(client: &RpcClient, pubkey: &Pubkey) -> Result<Metadata, 
         .get_account_data(pubkey)
         .map_err(|e| DecodeError::ClientError(e.kind))?;
 
-    <Metadata as BorshDeserialize>::deserialize(&mut account_data.as_ref())
+    Metadata::safe_deserialize(&mut account_data.as_ref())
         .map_err(|e| DecodeError::DecodeMetadataFailed(e.to_string()))
 }
 


### PR DESCRIPTION
Switch from `Metadata::deserialize()` to `Metadata::safe_deserialize()` to fix metadata account decoding errors.

Current version:
```console
# mint: A3vHW25cz9D5Ua3V94M5Nh2LVLmpeZ6QrfnLTzxFpBdA
> metaboss decode metadata -a 4ZxPzMm62fyDBKN2Tn4LXe5D9zVxEG8hrs91fgjwHxKF
Error: failed to decode metadata
```

see: metaplex-foundation/mpl-token-metadata#68
closes samuelvanderwaal/metaboss#309