### PR TITLE
Add unit tests for pure-logic functions

### DIFF
--- a/src/check/mod.rs
+++ b/src/check/mod.rs
@@ -179,3 +179,327 @@ fn token_standard_to_string(token_standard: &TokenStandard) -> String {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mpl_token_metadata::accounts::Metadata;
+    use mpl_token_metadata::types::{Collection, Key, ProgrammableConfig, TokenStandard};
+    use solana_sdk::pubkey::Pubkey;
+
+    fn make_test_metadata() -> Metadata {
+        Metadata {
+            key: Key::MetadataV1,
+            update_authority: Pubkey::default(),
+            mint: Pubkey::default(),
+            name: String::from("Test NFT"),
+            symbol: String::from("TEST"),
+            uri: String::from("https://example.com"),
+            seller_fee_basis_points: 500,
+            creators: None,
+            primary_sale_happened: false,
+            is_mutable: true,
+            edition_nonce: None,
+            token_standard: None,
+            collection: None,
+            uses: None,
+            collection_details: None,
+            programmable_config: None,
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // MetadataValue::from_str tests
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn parse_name() {
+        let v = MetadataValue::from_str("name=My NFT").unwrap();
+        assert!(matches!(v, MetadataValue::Name(ref s) if s == "My NFT"));
+    }
+
+    #[test]
+    fn parse_symbol() {
+        let v = MetadataValue::from_str("symbol=SYM").unwrap();
+        assert!(matches!(v, MetadataValue::Symbol(ref s) if s == "SYM"));
+    }
+
+    #[test]
+    fn parse_uri() {
+        let v = MetadataValue::from_str("uri=https://example.com").unwrap();
+        assert!(matches!(v, MetadataValue::Uri(ref s) if s == "https://example.com"));
+    }
+
+    #[test]
+    fn parse_sfbp() {
+        let v = MetadataValue::from_str("sfbp=500").unwrap();
+        assert!(matches!(v, MetadataValue::SellerFeeBasisPoints(500)));
+    }
+
+    #[test]
+    fn parse_creators() {
+        let v =
+            MetadataValue::from_str("creators=11111111111111111111111111111111:50:true").unwrap();
+        match v {
+            MetadataValue::Creators(ref creators) => {
+                assert_eq!(creators.len(), 1);
+                assert_eq!(creators[0].address, Pubkey::default());
+                assert_eq!(creators[0].share, 50);
+                assert!(creators[0].verified);
+            }
+            _ => panic!("Expected Creators variant"),
+        }
+    }
+
+    #[test]
+    fn parse_update_authority() {
+        let v =
+            MetadataValue::from_str("update_authority=11111111111111111111111111111111").unwrap();
+        assert!(
+            matches!(v, MetadataValue::UpdateAuthority(ref s) if s == "11111111111111111111111111111111")
+        );
+    }
+
+    #[test]
+    fn parse_primary_sale_happened() {
+        let v = MetadataValue::from_str("primary_sale_happened=true").unwrap();
+        assert!(matches!(v, MetadataValue::PrimarySaleHappened(true)));
+    }
+
+    #[test]
+    fn parse_is_mutable() {
+        let v = MetadataValue::from_str("is_mutable=false").unwrap();
+        assert!(matches!(v, MetadataValue::IsMutable(false)));
+    }
+
+    #[test]
+    fn parse_token_standard() {
+        let v = MetadataValue::from_str("token_standard=nonfungible").unwrap();
+        assert!(matches!(v, MetadataValue::TokenStandard(ref s) if s == "nonfungible"));
+    }
+
+    #[test]
+    fn parse_collection_parent() {
+        let v =
+            MetadataValue::from_str("collection_parent=11111111111111111111111111111111").unwrap();
+        assert!(
+            matches!(v, MetadataValue::CollectionParent(ref s) if s == "11111111111111111111111111111111")
+        );
+    }
+
+    #[test]
+    fn parse_collection_verified() {
+        let v = MetadataValue::from_str("collection_verified=true").unwrap();
+        assert!(matches!(v, MetadataValue::CollectionVerified(true)));
+    }
+
+    #[test]
+    fn parse_rule_set() {
+        let v = MetadataValue::from_str("rule_set=11111111111111111111111111111111").unwrap();
+        assert!(
+            matches!(v, MetadataValue::RuleSet(ref s) if s == "11111111111111111111111111111111")
+        );
+    }
+
+    #[test]
+    fn parse_invalid_key_returns_error() {
+        let result = MetadataValue::from_str("bad_key=whatever");
+        assert!(result.is_err());
+    }
+
+    // ---------------------------------------------------------------
+    // MetadataValue::Display tests
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn display_name() {
+        let v = MetadataValue::Name("My NFT".to_string());
+        assert_eq!(v.to_string(), "name=My NFT");
+    }
+
+    #[test]
+    fn display_sfbp() {
+        let v = MetadataValue::SellerFeeBasisPoints(500);
+        assert_eq!(v.to_string(), "sfbp=500");
+    }
+
+    #[test]
+    fn display_is_mutable() {
+        let v = MetadataValue::IsMutable(true);
+        assert_eq!(v.to_string(), "is_mutable=true");
+    }
+
+    #[test]
+    fn display_round_trip_name() {
+        let original = "name=My NFT";
+        let parsed = MetadataValue::from_str(original).unwrap();
+        assert_eq!(parsed.to_string(), original);
+    }
+
+    #[test]
+    fn display_round_trip_sfbp() {
+        let original = "sfbp=500";
+        let parsed = MetadataValue::from_str(original).unwrap();
+        assert_eq!(parsed.to_string(), original);
+    }
+
+    #[test]
+    fn display_round_trip_is_mutable() {
+        let original = "is_mutable=false";
+        let parsed = MetadataValue::from_str(original).unwrap();
+        assert_eq!(parsed.to_string(), original);
+    }
+
+    // ---------------------------------------------------------------
+    // check_metadata_value tests
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn check_name_matches() {
+        let md = make_test_metadata();
+        let v = MetadataValue::Name("Test NFT".to_string());
+        assert!(check_metadata_value(&md, &v));
+    }
+
+    #[test]
+    fn check_name_with_null_bytes() {
+        let mut md = make_test_metadata();
+        md.name = "Test NFT\0\0\0".to_string();
+        let v = MetadataValue::Name("Test NFT".to_string());
+        assert!(check_metadata_value(&md, &v));
+    }
+
+    #[test]
+    fn check_name_mismatch() {
+        let md = make_test_metadata();
+        let v = MetadataValue::Name("Other".to_string());
+        assert!(!check_metadata_value(&md, &v));
+    }
+
+    #[test]
+    fn check_symbol_matches() {
+        let md = make_test_metadata();
+        let v = MetadataValue::Symbol("TEST".to_string());
+        assert!(check_metadata_value(&md, &v));
+    }
+
+    #[test]
+    fn check_uri_matches() {
+        let md = make_test_metadata();
+        let v = MetadataValue::Uri("https://example.com".to_string());
+        assert!(check_metadata_value(&md, &v));
+    }
+
+    #[test]
+    fn check_sfbp_matches() {
+        let md = make_test_metadata();
+        let v = MetadataValue::SellerFeeBasisPoints(500);
+        assert!(check_metadata_value(&md, &v));
+    }
+
+    #[test]
+    fn check_sfbp_mismatch() {
+        let md = make_test_metadata();
+        let v = MetadataValue::SellerFeeBasisPoints(1000);
+        assert!(!check_metadata_value(&md, &v));
+    }
+
+    #[test]
+    fn check_is_mutable_matches() {
+        let md = make_test_metadata();
+        let v = MetadataValue::IsMutable(true);
+        assert!(check_metadata_value(&md, &v));
+    }
+
+    #[test]
+    fn check_is_mutable_mismatch() {
+        let md = make_test_metadata();
+        let v = MetadataValue::IsMutable(false);
+        assert!(!check_metadata_value(&md, &v));
+    }
+
+    #[test]
+    fn check_primary_sale_happened_matches() {
+        let md = make_test_metadata();
+        let v = MetadataValue::PrimarySaleHappened(false);
+        assert!(check_metadata_value(&md, &v));
+    }
+
+    #[test]
+    fn check_update_authority_matches() {
+        let md = make_test_metadata();
+        let v = MetadataValue::UpdateAuthority(Pubkey::default().to_string());
+        assert!(check_metadata_value(&md, &v));
+    }
+
+    #[test]
+    fn check_token_standard_matches() {
+        let mut md = make_test_metadata();
+        md.token_standard = Some(TokenStandard::NonFungible);
+        let v = MetadataValue::TokenStandard("nonfungible".to_string());
+        assert!(check_metadata_value(&md, &v));
+    }
+
+    #[test]
+    fn check_token_standard_none_returns_false() {
+        let md = make_test_metadata();
+        let v = MetadataValue::TokenStandard("nonfungible".to_string());
+        assert!(!check_metadata_value(&md, &v));
+    }
+
+    #[test]
+    fn check_collection_parent_matches() {
+        let pubkey = Pubkey::default();
+        let mut md = make_test_metadata();
+        md.collection = Some(Collection {
+            verified: true,
+            key: pubkey,
+        });
+        let v = MetadataValue::CollectionParent(pubkey.to_string());
+        assert!(check_metadata_value(&md, &v));
+    }
+
+    #[test]
+    fn check_collection_verified_matches() {
+        let mut md = make_test_metadata();
+        md.collection = Some(Collection {
+            verified: true,
+            key: Pubkey::default(),
+        });
+        let v = MetadataValue::CollectionVerified(true);
+        assert!(check_metadata_value(&md, &v));
+    }
+
+    #[test]
+    fn check_collection_verified_no_collection() {
+        let md = make_test_metadata();
+        let v = MetadataValue::CollectionVerified(true);
+        assert!(!check_metadata_value(&md, &v));
+    }
+
+    #[test]
+    fn check_rule_set_matches() {
+        let pubkey = Pubkey::default();
+        let mut md = make_test_metadata();
+        md.programmable_config = Some(ProgrammableConfig::V1 {
+            rule_set: Some(pubkey),
+        });
+        let v = MetadataValue::RuleSet(pubkey.to_string());
+        assert!(check_metadata_value(&md, &v));
+    }
+
+    #[test]
+    fn check_rule_set_none_config() {
+        let md = make_test_metadata();
+        let v = MetadataValue::RuleSet(Pubkey::default().to_string());
+        assert!(!check_metadata_value(&md, &v));
+    }
+
+    #[test]
+    fn check_rule_set_none_rule_set() {
+        let mut md = make_test_metadata();
+        md.programmable_config = Some(ProgrammableConfig::V1 { rule_set: None });
+        let v = MetadataValue::RuleSet(Pubkey::default().to_string());
+        assert!(!check_metadata_value(&md, &v));
+    }
+}

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -32,3 +32,88 @@ fn convert_creator(c: &NftCreator) -> Result<Creator> {
         share: c.share,
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_creator(address: &str, verified: bool, share: u8) -> NftCreator {
+        NftCreator {
+            address: address.to_string(),
+            verified,
+            share,
+        }
+    }
+
+    fn make_nft_data(creators: Option<Vec<NftCreator>>) -> NftData {
+        NftData {
+            name: "Test NFT".to_string(),
+            symbol: "TNFT".to_string(),
+            uri: "https://example.com/nft.json".to_string(),
+            seller_fee_basis_points: 500,
+            creators,
+        }
+    }
+
+    #[test]
+    fn test_convert_local_to_remote_data_valid() {
+        let pubkey_str = "11111111111111111111111111111111";
+        let creators = vec![make_creator(pubkey_str, true, 100)];
+        let nft_data = make_nft_data(Some(creators));
+
+        let result = convert_local_to_remote_data(nft_data).unwrap();
+
+        assert_eq!(result.name, "Test NFT");
+        assert_eq!(result.symbol, "TNFT");
+        assert_eq!(result.uri, "https://example.com/nft.json");
+        assert_eq!(result.seller_fee_basis_points, 500);
+        assert!(result.collection.is_none());
+        assert!(result.uses.is_none());
+
+        let creators = result.creators.unwrap();
+        assert_eq!(creators.len(), 1);
+        assert_eq!(creators[0].address, Pubkey::from_str(pubkey_str).unwrap());
+        assert!(creators[0].verified);
+        assert_eq!(creators[0].share, 100);
+    }
+
+    #[test]
+    fn test_convert_local_to_remote_data_none_creators() {
+        let nft_data = make_nft_data(None);
+        let result = convert_local_to_remote_data(nft_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_convert_local_to_remote_data_invalid_pubkey() {
+        let creators = vec![make_creator("not-a-pubkey", false, 100)];
+        let nft_data = make_nft_data(Some(creators));
+        let result = convert_local_to_remote_data(nft_data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_convert_local_to_remote_data_multiple_creators() {
+        let pubkey_str = "11111111111111111111111111111111";
+        let creators = vec![
+            make_creator(pubkey_str, true, 50),
+            make_creator(pubkey_str, false, 30),
+            make_creator(pubkey_str, true, 20),
+        ];
+        let nft_data = make_nft_data(Some(creators));
+
+        let result = convert_local_to_remote_data(nft_data).unwrap();
+        let creators = result.creators.unwrap();
+
+        assert_eq!(creators.len(), 3);
+
+        assert!(creators[0].verified);
+        assert_eq!(creators[0].share, 50);
+
+        assert!(!creators[1].verified);
+        assert_eq!(creators[1].share, 30);
+
+        assert!(creators[2].verified);
+        assert_eq!(creators[2].share, 20);
+    }
+}

--- a/src/data.rs
+++ b/src/data.rs
@@ -186,3 +186,157 @@ impl Display for Priority {
 
 // Temporary values--calculate this properly later.
 pub const UPDATE_COMPUTE_UNITS: u32 = 50_000;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    use mpl_token_metadata::types::{Creator, DataV2};
+    use solana_sdk::pubkey::Pubkey;
+
+    use crate::derive::{derive_edition_pda, derive_metadata_pda};
+
+    // --- Priority::from_str ---
+
+    #[test]
+    fn test_priority_from_str_valid_lowercase() {
+        assert_eq!(Priority::from_str("none").unwrap(), Priority::None);
+        assert_eq!(Priority::from_str("low").unwrap(), Priority::Low);
+        assert_eq!(Priority::from_str("medium").unwrap(), Priority::Medium);
+        assert_eq!(Priority::from_str("high").unwrap(), Priority::High);
+        assert_eq!(Priority::from_str("max").unwrap(), Priority::Max);
+    }
+
+    #[test]
+    fn test_priority_from_str_case_insensitive() {
+        assert_eq!(Priority::from_str("None").unwrap(), Priority::None);
+        assert_eq!(Priority::from_str("HIGH").unwrap(), Priority::High);
+        assert_eq!(Priority::from_str("Medium").unwrap(), Priority::Medium);
+        assert_eq!(Priority::from_str("LOW").unwrap(), Priority::Low);
+        assert_eq!(Priority::from_str("Max").unwrap(), Priority::Max);
+    }
+
+    #[test]
+    fn test_priority_from_str_invalid() {
+        assert!(Priority::from_str("invalid").is_err());
+        assert!(Priority::from_str("").is_err());
+        assert!(Priority::from_str("ultra").is_err());
+    }
+
+    // --- Priority::Display ---
+
+    #[test]
+    fn test_priority_display() {
+        assert_eq!(format!("{}", Priority::None), "None");
+        assert_eq!(format!("{}", Priority::Low), "Low");
+        assert_eq!(format!("{}", Priority::Medium), "Medium");
+        assert_eq!(format!("{}", Priority::High), "High");
+        assert_eq!(format!("{}", Priority::Max), "Max");
+    }
+
+    #[test]
+    fn test_priority_display_roundtrip() {
+        let variants = [
+            Priority::None,
+            Priority::Low,
+            Priority::Medium,
+            Priority::High,
+            Priority::Max,
+        ];
+        for variant in &variants {
+            let displayed = format!("{}", variant);
+            let parsed = Priority::from_str(&displayed).unwrap();
+            assert_eq!(&parsed, variant);
+        }
+    }
+
+    // --- PriorityFee::Display ---
+
+    #[test]
+    fn test_priority_fee_display() {
+        let fee = PriorityFee {
+            compute: 200_000,
+            fee: 5000,
+        };
+        assert_eq!(format!("{}", fee), "compute: 200000, fee: 5000");
+    }
+
+    // --- NftData::from(DataV2) ---
+
+    #[test]
+    fn test_nft_data_from_data_v2_with_creators() {
+        let creator_pubkey = Pubkey::new_unique();
+        let data = DataV2 {
+            name: "Test NFT".to_string(),
+            symbol: "TNFT".to_string(),
+            uri: "https://example.com/nft.json".to_string(),
+            seller_fee_basis_points: 500,
+            creators: Some(vec![Creator {
+                address: creator_pubkey,
+                verified: true,
+                share: 100,
+            }]),
+            collection: None,
+            uses: None,
+        };
+
+        let nft_data: NftData = data.into();
+
+        assert_eq!(nft_data.name, "Test NFT");
+        assert_eq!(nft_data.symbol, "TNFT");
+        assert_eq!(nft_data.uri, "https://example.com/nft.json");
+        assert_eq!(nft_data.seller_fee_basis_points, 500);
+
+        let creators = nft_data.creators.unwrap();
+        assert_eq!(creators.len(), 1);
+        assert_eq!(creators[0].address, creator_pubkey.to_string());
+        assert!(creators[0].verified);
+        assert_eq!(creators[0].share, 100);
+    }
+
+    #[test]
+    fn test_nft_data_from_data_v2_no_creators() {
+        let data = DataV2 {
+            name: "No Creator NFT".to_string(),
+            symbol: "NC".to_string(),
+            uri: "https://example.com/nc.json".to_string(),
+            seller_fee_basis_points: 0,
+            creators: None,
+            collection: None,
+            uses: None,
+        };
+
+        let nft_data: NftData = data.into();
+
+        assert_eq!(nft_data.name, "No Creator NFT");
+        assert_eq!(nft_data.symbol, "NC");
+        assert_eq!(nft_data.uri, "https://example.com/nc.json");
+        assert_eq!(nft_data.seller_fee_basis_points, 0);
+        assert!(nft_data.creators.is_none());
+    }
+
+    // --- Asset::new ---
+
+    #[test]
+    fn test_asset_new() {
+        let mint = Pubkey::new_unique();
+        let asset = Asset::new(mint);
+
+        assert_eq!(asset.mint, mint);
+        assert_eq!(asset.metadata, derive_metadata_pda(&mint));
+        assert!(asset.edition.is_none());
+    }
+
+    // --- Asset::add_edition ---
+
+    #[test]
+    fn test_asset_add_edition() {
+        let mint = Pubkey::new_unique();
+        let mut asset = Asset::new(mint);
+
+        assert!(asset.edition.is_none());
+        asset.add_edition();
+        assert_eq!(asset.edition, Some(derive_edition_pda(&mint)));
+    }
+}

--- a/src/derive/mod.rs
+++ b/src/derive/mod.rs
@@ -166,4 +166,63 @@ mod tests {
             Pubkey::from_str("8J9W44AfgWFMSwE4iYyZMNCWV9mKqovS5YHiVoKuuA2b").unwrap();
         assert_eq!(derive_cmv2_pda(&candy_machine_pubkey), expected_pda);
     }
+
+    #[test]
+    fn test_derive_edition_marker_pda() {
+        let mint = Pubkey::from_str("H9UJFx7HknQ9GUz7RBqqV9SRnht6XaVDh2cZS3Huogpf").unwrap();
+
+        let pda_0 = derive_edition_marker_pda(&mint, 0);
+        let pda_248 = derive_edition_marker_pda(&mint, 248);
+
+        // edition_num 0 => marker 0, edition_num 248 => marker 1, so PDAs differ
+        assert_ne!(pda_0, pda_248);
+        // Both should be valid (non-default) pubkeys
+        assert_ne!(pda_0, Pubkey::default());
+        assert_ne!(pda_248, Pubkey::default());
+    }
+
+    #[test]
+    fn test_derive_token_record_pda() {
+        let mint = Pubkey::from_str("H9UJFx7HknQ9GUz7RBqqV9SRnht6XaVDh2cZS3Huogpf").unwrap();
+        let token = Pubkey::from_str("3qt9aBBmTSMxyzFEcwzZnFeV4tCZzPkTYVqPP7Bw5zUh").unwrap();
+
+        let pda1 = derive_token_record_pda(&mint, &token);
+        let pda2 = derive_token_record_pda(&mint, &token);
+
+        // Deterministic
+        assert_eq!(pda1, pda2);
+        // Valid pubkey
+        assert_ne!(pda1, Pubkey::default());
+    }
+
+    #[test]
+    fn test_derive_collection_delegate_pda() {
+        let mint = Pubkey::from_str("H9UJFx7HknQ9GUz7RBqqV9SRnht6XaVDh2cZS3Huogpf").unwrap();
+        let delegate = Pubkey::from_str("3qt9aBBmTSMxyzFEcwzZnFeV4tCZzPkTYVqPP7Bw5zUh").unwrap();
+        let authority = Pubkey::from_str("8J9W44AfgWFMSwE4iYyZMNCWV9mKqovS5YHiVoKuuA2b").unwrap();
+
+        let pda1 = derive_collection_delegate_pda(&mint, &delegate, &authority);
+        let pda2 = derive_collection_delegate_pda(&mint, &delegate, &authority);
+
+        // Deterministic
+        assert_eq!(pda1, pda2);
+        // Different from metadata PDA
+        let metadata_pda = derive_metadata_pda(&mint);
+        assert_ne!(pda1, metadata_pda);
+    }
+
+    #[test]
+    fn test_derive_collection_item_delegate_pda() {
+        let mint = Pubkey::from_str("H9UJFx7HknQ9GUz7RBqqV9SRnht6XaVDh2cZS3Huogpf").unwrap();
+        let delegate = Pubkey::from_str("3qt9aBBmTSMxyzFEcwzZnFeV4tCZzPkTYVqPP7Bw5zUh").unwrap();
+        let authority = Pubkey::from_str("8J9W44AfgWFMSwE4iYyZMNCWV9mKqovS5YHiVoKuuA2b").unwrap();
+
+        let collection_pda = derive_collection_delegate_pda(&mint, &delegate, &authority);
+        let item_pda = derive_collection_item_delegate_pda(&mint, &delegate, &authority);
+
+        // Different delegate roles produce different PDAs
+        assert_ne!(collection_pda, item_pda);
+        // Valid pubkey
+        assert_ne!(item_pda, Pubkey::default());
+    }
 }

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -237,3 +237,44 @@ where
 
     Ok(update_ix)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_v1_update_args_default() {
+        let args = V1UpdateArgs::default();
+
+        assert_eq!(args.new_update_authority, None);
+        assert_eq!(args.data, None);
+        assert_eq!(args.primary_sale_happened, None);
+        assert_eq!(args.is_mutable, None);
+        assert_eq!(args.collection, CollectionToggle::None);
+        assert_eq!(args.collection_details, CollectionDetailsToggle::None);
+        assert_eq!(args.uses, UsesToggle::None);
+        assert_eq!(args.rule_set, RuleSetToggle::None);
+        assert_eq!(args.authorization_data, None);
+    }
+
+    #[test]
+    fn test_v1_update_args_into_instruction_args() {
+        let args = V1UpdateArgs {
+            is_mutable: Some(false),
+            primary_sale_happened: Some(true),
+            ..V1UpdateArgs::default()
+        };
+
+        let ix_args: UpdateV1InstructionArgs = args.into();
+
+        assert_eq!(ix_args.is_mutable, Some(false));
+        assert_eq!(ix_args.primary_sale_happened, Some(true));
+        assert_eq!(ix_args.new_update_authority, None);
+        assert_eq!(ix_args.data, None);
+        assert_eq!(ix_args.collection, CollectionToggle::None);
+        assert_eq!(ix_args.collection_details, CollectionDetailsToggle::None);
+        assert_eq!(ix_args.uses, UsesToggle::None);
+        assert_eq!(ix_args.rule_set, RuleSetToggle::None);
+        assert_eq!(ix_args.authorization_data, None);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds **58 new unit tests** across 5 source files, covering all pure-logic functions that can be tested without an RPC connection
- Increases test count from 4 to 62 (all pass in ~0.00s)
- No production code changes — test modules only

## Test coverage added

| File | Tests | What's covered |
|------|-------|----------------|
| `src/data.rs` | 10 | `Priority` FromStr/Display/roundtrip, `PriorityFee` Display, `NftData::from(DataV2)`, `Asset::new()`, `Asset::add_edition()` |
| `src/check/mod.rs` | 38 | All 12 `MetadataValue::from_str` variants + invalid key, Display + round-trips, `check_metadata_value` match/mismatch for all field types |
| `src/convert.rs` | 4 | Valid conversion, None creators error, invalid pubkey error, multiple creators |
| `src/derive/mod.rs` | 4 | `derive_edition_marker_pda`, `derive_token_record_pda`, `derive_collection_delegate_pda`, `derive_collection_item_delegate_pda` |
| `src/update/mod.rs` | 2 | `V1UpdateArgs::default()` fields, `Into<UpdateV1InstructionArgs>` conversion |

## Test plan
- [x] `cargo test` — 62 tests pass
- [x] `cargo fmt --check` — clean
- [x] No new clippy warnings in modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)