### PR TITLE
Pin CI to Rust 1.93 and fix all clippy lints

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,14 +20,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Install Latest Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          default: true
-          override: true
+      - name: Install Rust 1.93
+        uses: dtolnay/rust-toolchain@1.93
 
       - name: Build
         id: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,44 +11,26 @@ jobs:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.93
+      - run: cargo test
 
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.93
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+          components: rustfmt
+      - run: cargo fmt --all -- --check
 
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.93
         with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add clippy
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+          components: clippy
+      - run: cargo clippy -- -D warnings

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+ORCHESTRATOR.md

--- a/src/decode/errors.rs
+++ b/src/decode/errors.rs
@@ -7,7 +7,7 @@ pub enum DecodeError {
     MissingAccount(String),
 
     #[error("failed to get account data")]
-    ClientError(ClientErrorKind),
+    ClientError(Box<ClientErrorKind>),
 
     #[error("failed to parse string into Pubkey")]
     PubkeyParseFailed(String),

--- a/src/decode/mod.rs
+++ b/src/decode/mod.rs
@@ -41,7 +41,7 @@ impl ToPubkey for Pubkey {
 pub fn decode_metadata(client: &RpcClient, pubkey: &Pubkey) -> Result<Metadata, DecodeError> {
     let account_data = client
         .get_account_data(pubkey)
-        .map_err(|e| DecodeError::ClientError(e.kind))?;
+        .map_err(|e| DecodeError::ClientError(Box::new(e.kind)))?;
 
     Metadata::safe_deserialize(account_data.as_ref())
         .map_err(|e| DecodeError::DecodeMetadataFailed(e.to_string()))
@@ -51,7 +51,7 @@ pub fn decode_master(client: &RpcClient, pubkey: &Pubkey) -> Result<MasterEditio
     let account_data = match client.get_account_data(pubkey) {
         Ok(data) => data,
         Err(err) => {
-            return Err(DecodeError::ClientError(err.kind));
+            return Err(DecodeError::ClientError(Box::new(err.kind)));
         }
     };
 
@@ -68,7 +68,7 @@ pub fn decode_edition(client: &RpcClient, pubkey: &Pubkey) -> Result<Edition, De
     let account_data = match client.get_account_data(pubkey) {
         Ok(data) => data,
         Err(err) => {
-            return Err(DecodeError::ClientError(err.kind));
+            return Err(DecodeError::ClientError(Box::new(err.kind)));
         }
     };
 
@@ -119,7 +119,7 @@ pub fn decode_mint<P: ToPubkey>(client: &RpcClient, mint_address: P) -> Result<M
     let account = match client.get_account(&pubkey) {
         Ok(account) => account,
         Err(err) => {
-            return Err(DecodeError::ClientError(err.kind));
+            return Err(DecodeError::ClientError(Box::new(err.kind)));
         }
     };
 
@@ -140,7 +140,7 @@ pub fn decode_token<P: ToPubkey>(
     let account_data = match client.get_account_data(&pubkey) {
         Ok(data) => data,
         Err(err) => {
-            return Err(DecodeError::ClientError(err.kind));
+            return Err(DecodeError::ClientError(Box::new(err.kind)));
         }
     };
 
@@ -171,7 +171,7 @@ pub fn decode_edition_marker<P: ToPubkey>(
     let account_data = match client.get_account_data(pubkey) {
         Ok(data) => data,
         Err(err) => {
-            return Err(DecodeError::ClientError(err.kind));
+            return Err(DecodeError::ClientError(Box::new(err.kind)));
         }
     };
 
@@ -192,7 +192,7 @@ pub fn decode_bpf_loader_upgradeable_state<P: ToPubkey>(
 
     let account = client
         .get_account(&pubkey)
-        .map_err(|err| DecodeError::ClientError(err.kind))?;
+        .map_err(|err| DecodeError::ClientError(Box::new(err.kind)))?;
 
     let upgradeable_loader_state: UpgradeableLoaderState = account
         .state()
@@ -209,7 +209,7 @@ pub fn decode_collection_authority_record<P: ToPubkey>(
 
     let account_data = client
         .get_account_data(&pubkey)
-        .map_err(|e| DecodeError::ClientError(e.kind))?;
+        .map_err(|e| DecodeError::ClientError(Box::new(e.kind)))?;
 
     <CollectionAuthorityRecord as BorshDeserialize>::deserialize(&mut account_data.as_slice())
         .map_err(|e| DecodeError::DeserializationFailed(e.to_string()))
@@ -223,7 +223,7 @@ pub fn decode_use_authority_record<P: ToPubkey>(
 
     let account_data = client
         .get_account_data(&pubkey)
-        .map_err(|e| DecodeError::ClientError(e.kind))?;
+        .map_err(|e| DecodeError::ClientError(Box::new(e.kind)))?;
 
     <UseAuthorityRecord as BorshDeserialize>::deserialize(&mut account_data.as_slice())
         .map_err(|e| DecodeError::DeserializationFailed(e.to_string()))
@@ -237,7 +237,7 @@ pub fn decode_metadata_delegate<P: ToPubkey>(
 
     let account_data = client
         .get_account_data(&pubkey)
-        .map_err(|e| DecodeError::ClientError(e.kind))?;
+        .map_err(|e| DecodeError::ClientError(Box::new(e.kind)))?;
 
     <MetadataDelegateRecord as BorshDeserialize>::deserialize(&mut account_data.as_slice())
         .map_err(|e| DecodeError::DeserializationFailed(e.to_string()))
@@ -251,7 +251,7 @@ pub fn decode_token_record<P: ToPubkey>(
 
     let account_data = client
         .get_account_data(&pubkey)
-        .map_err(|e| DecodeError::ClientError(e.kind))?;
+        .map_err(|e| DecodeError::ClientError(Box::new(e.kind)))?;
 
     <TokenRecord as BorshDeserialize>::deserialize(&mut account_data.as_slice())
         .map_err(|e| DecodeError::DeserializationFailed(e.to_string()))
@@ -270,7 +270,7 @@ pub fn decode_token_record_from_mint<P: ToPubkey>(
 
     let account_data = client
         .get_account_data(&token_record_pda)
-        .map_err(|e| DecodeError::ClientError(e.kind))?;
+        .map_err(|e| DecodeError::ClientError(Box::new(e.kind)))?;
 
     <TokenRecord as BorshDeserialize>::deserialize(&mut account_data.as_slice())
         .map_err(|e| DecodeError::DeserializationFailed(e.to_string()))

--- a/src/decode/rule_set.rs
+++ b/src/decode/rule_set.rs
@@ -16,7 +16,7 @@ pub fn decode_rule_set(
 ) -> Result<RuleSetV1, DecodeError> {
     let account_data = client
         .get_account_data(rule_set_pubkey)
-        .map_err(|e| DecodeError::ClientError(e.kind))?;
+        .map_err(|e| DecodeError::ClientError(Box::new(e.kind)))?;
 
     let (revision_map, rev_map_location) =
         get_existing_revision_map(client, rule_set_pubkey).unwrap();

--- a/src/revoke/mod.rs
+++ b/src/revoke/mod.rs
@@ -142,17 +142,17 @@ where
     };
 
     match revoke_args {
-        RevokeArgs::SaleV1 { .. }
-        | RevokeArgs::TransferV1 { .. }
-        | RevokeArgs::UtilityV1 { .. }
-        | RevokeArgs::StakingV1 { .. }
-        | RevokeArgs::LockedTransferV1 { .. }
-        | RevokeArgs::PrintDelegateV1 { .. }
+        RevokeArgs::SaleV1
+        | RevokeArgs::TransferV1
+        | RevokeArgs::UtilityV1
+        | RevokeArgs::StakingV1
+        | RevokeArgs::LockedTransferV1
+        | RevokeArgs::PrintDelegateV1
         | RevokeArgs::MigrationV1 => {
             let (token_record, _) = TokenRecord::find_pda(&mint, &token);
             revoke_accounts.token_record = Some(token_record);
         }
-        RevokeArgs::AuthorityItemV1 { .. } => {
+        RevokeArgs::AuthorityItemV1 => {
             let (delegate_record, _) = MetadataDelegateRecord::find_pda(
                 &mint,
                 MetadataDelegateRoleSeed::from(MetadataDelegateRole::AuthorityItem),
@@ -161,7 +161,7 @@ where
             );
             revoke_accounts.delegate_record = Some(delegate_record);
         }
-        RevokeArgs::DataV1 { .. } => {
+        RevokeArgs::DataV1 => {
             let (delegate_record, _) = MetadataDelegateRecord::find_pda(
                 &mint,
                 MetadataDelegateRoleSeed::from(MetadataDelegateRole::Data),
@@ -170,7 +170,7 @@ where
             );
             revoke_accounts.delegate_record = Some(delegate_record);
         }
-        RevokeArgs::DataItemV1 { .. } => {
+        RevokeArgs::DataItemV1 => {
             let (delegate_record, _) = MetadataDelegateRecord::find_pda(
                 &mint,
                 MetadataDelegateRoleSeed::from(MetadataDelegateRole::DataItem),
@@ -179,7 +179,7 @@ where
             );
             revoke_accounts.delegate_record = Some(delegate_record);
         }
-        RevokeArgs::CollectionV1 { .. } => {
+        RevokeArgs::CollectionV1 => {
             let (delegate_record, _) = MetadataDelegateRecord::find_pda(
                 &mint,
                 MetadataDelegateRoleSeed::from(MetadataDelegateRole::Collection),
@@ -188,7 +188,7 @@ where
             );
             revoke_accounts.delegate_record = Some(delegate_record);
         }
-        RevokeArgs::CollectionItemV1 { .. } => {
+        RevokeArgs::CollectionItemV1 => {
             let (delegate_record, _) = MetadataDelegateRecord::find_pda(
                 &mint,
                 MetadataDelegateRoleSeed::from(MetadataDelegateRole::CollectionItem),
@@ -197,7 +197,7 @@ where
             );
             revoke_accounts.delegate_record = Some(delegate_record);
         }
-        RevokeArgs::ProgrammableConfigV1 { .. } => {
+        RevokeArgs::ProgrammableConfigV1 => {
             let (delegate_record, _) = MetadataDelegateRecord::find_pda(
                 &mint,
                 MetadataDelegateRoleSeed::from(MetadataDelegateRole::ProgrammableConfig),
@@ -206,7 +206,7 @@ where
             );
             revoke_accounts.delegate_record = Some(delegate_record);
         }
-        RevokeArgs::ProgrammableConfigItemV1 { .. } => {
+        RevokeArgs::ProgrammableConfigItemV1 => {
             let (delegate_record, _) = MetadataDelegateRecord::find_pda(
                 &mint,
                 MetadataDelegateRoleSeed::from(MetadataDelegateRole::ProgrammableConfigItem),
@@ -215,7 +215,7 @@ where
             );
             revoke_accounts.delegate_record = Some(delegate_record);
         }
-        RevokeArgs::StandardV1 { .. } => { /* nothing to add */ }
+        RevokeArgs::StandardV1 => { /* nothing to add */ }
     }
 
     // Fungibles without a token standard will fail when an edition is passed in, but

--- a/src/snapshot/errors.rs
+++ b/src/snapshot/errors.rs
@@ -7,7 +7,7 @@ pub enum SnapshotError {
     MissingAccount(String),
 
     #[error("failed to get account data")]
-    ClientError(ClientErrorKind),
+    ClientError(Box<ClientErrorKind>),
 
     #[error("failed to parse string into Pubkey")]
     PubkeyParseFailed(String),

--- a/src/snapshot/mod.rs
+++ b/src/snapshot/mod.rs
@@ -42,7 +42,7 @@ pub fn get_metadata_accounts_by_update_authority(
     let accounts = match client.get_program_accounts_with_config(&TOKEN_METADATA_PROGRAM_ID, config)
     {
         Ok(accounts) => accounts,
-        Err(err) => return Err(SnapshotError::ClientError(err.kind)),
+        Err(err) => return Err(SnapshotError::ClientError(Box::new(err.kind))),
     };
 
     Ok(accounts)
@@ -76,7 +76,7 @@ pub fn get_metadata_accounts_by_creator(
     let accounts = match client.get_program_accounts_with_config(&TOKEN_METADATA_PROGRAM_ID, config)
     {
         Ok(accounts) => accounts,
-        Err(err) => return Err(SnapshotError::ClientError(err.kind)),
+        Err(err) => return Err(SnapshotError::ClientError(Box::new(err.kind))),
     };
 
     Ok(accounts)
@@ -111,7 +111,7 @@ pub fn get_holder_token_accounts(
     let holders = match client.get_program_accounts_with_config(&TOKEN_METADATA_PROGRAM_ID, config)
     {
         Ok(accounts) => accounts,
-        Err(err) => return Err(SnapshotError::ClientError(err.kind)),
+        Err(err) => return Err(SnapshotError::ClientError(Box::new(err.kind))),
     };
 
     Ok(holders)
@@ -151,7 +151,7 @@ pub fn get_edition_accounts_by_master(
     let accounts = match client.get_program_accounts_with_config(&TOKEN_METADATA_PROGRAM_ID, config)
     {
         Ok(accounts) => accounts,
-        Err(err) => return Err(SnapshotError::ClientError(err.kind)),
+        Err(err) => return Err(SnapshotError::ClientError(Box::new(err.kind))),
     };
 
     Ok(accounts)

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -42,6 +42,7 @@ pub fn send_and_confirm_tx_with_retries(
     let tx = transaction!(signers, ixs, client);
 
     // Send tx with retries.
+    #[allow(clippy::result_large_err)]
     let res = retry(
         Exponential::from_millis_with_factor(250, 2.0).take(3),
         || client.send_and_confirm_transaction_with_spinner(&tx),

--- a/src/update/mod.rs
+++ b/src/update/mod.rs
@@ -148,7 +148,7 @@ where
     let signers = vec![payer, authority];
 
     let update_ix = update_asset_v1_ix(client, args)?;
-    let units = get_compute_units(client, &[update_ix.clone()], &signers)?
+    let units = get_compute_units(client, std::slice::from_ref(&update_ix), &signers)?
         .unwrap_or(UPDATE_COMPUTE_UNITS as u64);
 
     let instructions = vec![


### PR DESCRIPTION
## Summary
- Pins CI toolchain to Rust 1.93 (matching local dev environment)
- Modernizes GitHub Actions (replaces deprecated `actions-rs/*` with `dtolnay/rust-toolchain`, updates checkout to v4)
- Fixes all clippy lints so `cargo clippy -- -D warnings` passes cleanly on 1.93

## Changes

**CI workflows:**
- `ci.yml`: `dtolnay/rust-toolchain@1.93`, direct `cargo` commands, `actions/checkout@v4`
- `build.yml`: same toolchain + checkout updates

**Clippy fixes:**
- `decode/errors.rs`, `snapshot/errors.rs`: Box `ClientErrorKind` to fix `result_large_err` (external type is ~200 bytes)
- `decode/mod.rs`, `decode/rule_set.rs`, `snapshot/mod.rs`: Wrap all `ClientErrorKind` construction sites with `Box::new()`
- `revoke/mod.rs`: Remove 14 unneeded `{ .. }` struct patterns on unit variants
- `update/mod.rs`: Replace `&[update_ix.clone()]` with `std::slice::from_ref(&update_ix)`
- `transaction.rs`: `#[allow(clippy::result_large_err)]` on retry closure (external `ClientError` type, can't box)

## Test plan
- [x] `cargo test` — 62 tests pass
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)