### PR TITLE
Fix Windows CI build: vendor OpenSSL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,16 +25,17 @@ jobs:
       - name: Install Rust 1.94
         uses: dtolnay/rust-toolchain@1.94
 
-      - name: Install OpenSSL (Windows)
+      - name: Install Perl (Windows)
         if: runner.os == 'Windows'
-        run: |
-          choco install openssl -y
-          echo "OPENSSL_DIR=C:\Program Files\OpenSSL-Win64" >> $GITHUB_ENV
-        shell: bash
+        uses: shogo82148/actions-setup-perl@v1
+        with:
+          perl-version: '5.38'
 
       - name: Build
         id: build
         shell: bash
+        env:
+          OPENSSL_STATIC: '1'
         run: |
           cargo build --all --release
       - name: Release Tags

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,4 +23,5 @@ solana-program = "=2.3.0"
 solana-sdk = "=2.3.1"
 spl-associated-token-account = "~7.0"
 spl-token = "~8.0"
+openssl = { version = "0.10", features = ["vendored"] }
 thiserror = "1.0.30"


### PR DESCRIPTION
## Summary
- Fixes Windows build failure caused by missing OpenSSL headers
- Vendors OpenSSL via the `openssl` crate's `vendored` feature so it compiles from bundled source
- Installs Perl on Windows runners (required by OpenSSL's build system)

## Changes
- **`Cargo.toml`**: Added `openssl = { version = "0.10", features = ["vendored"] }`
- **`build.yml`**: Replaced broken `choco install openssl` with `shogo82148/actions-setup-perl`, set `OPENSSL_STATIC=1`

## Context
Solana SDK 2.x transitively depends on `openssl-sys`. The previous fix installed OpenSSL via chocolatey, but the choco package doesn't include the `include` directory that `openssl-sys` needs to compile. Vendoring compiles OpenSSL from source, eliminating the system dependency entirely.

## Test plan
- [x] `cargo check` passes locally
- [ ] Windows CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)