### PR TITLE
ci: Remove Windows from build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - windows-latest
           - buildjet-16vcpu-ubuntu-2204
           - macos-latest
 
@@ -24,13 +23,6 @@ jobs:
 
       - name: Install Rust 1.94
         uses: dtolnay/rust-toolchain@1.94
-
-      - name: Install Strawberry Perl (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          choco install strawberryperl -y
-          echo "C:\Strawberry\perl\bin" >> $GITHUB_PATH
-        shell: bash
 
       - name: Build
         id: build


### PR DESCRIPTION
## Summary
- Removes `windows-latest` from the build matrix and the Strawberry Perl install step
- The vendored OpenSSL build consistently fails on Windows CI due to MSYS2/Git Bash's minimal Perl missing `Locale::Maketext::Simple`
- As a library crate, Windows users build locally with their own toolchain — a CI-produced Windows binary isn't needed

## Test plan
- [ ] Verify Linux and macOS builds pass in CI
- [ ] Confirm no Windows-specific steps remain in `build.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)